### PR TITLE
Convert to Playwright 10: Update docs with Playwright links and docs

### DIFF
--- a/stories/manual/chapters/testing.tsx
+++ b/stories/manual/chapters/testing.tsx
@@ -67,7 +67,7 @@ export const Page: PageType = () => {
                 <h2>Automated testing</h2>
                 <p>
                     Windrift ships with support for the browser testing framework{' '}
-                    <a href="https://www.cypress.io/">Cypress</a>, which it uses paired with this
+                    <a href="https://playwright.dev/">Playwright</a>, which it uses paired with this
                     manual's examples to verify that components and features work as expected. You
                     can use the same testing framework for your own stories. This can be especially
                     useful to detect when unexpected changes crop up as you work through a whole
@@ -75,25 +75,27 @@ export const Page: PageType = () => {
                     custom components.
                 </p>
                 <aside>
-                    To start up Cypress locally, run: <code>npm run cypress</code>
+                    To do all Playwright tests, run: <code>npm run test</code>
+                    To run a specific Playwright test, run:{' '}
+                    <code>npx playwright test FILENAME</code>
                 </aside>
                 <p>
-                    Put your tests in <code>cypress/integration/stories</code>—a few examples will
-                    be there already.
+                    Put your tests in <code>playwright/e2e/stories</code>—a few examples will be
+                    there already.
                 </p>
                 <h3>Automatic test running with Github Actions</h3>
                 <p>
-                    Github will automatically run any Cypress tests as a Github Action if you push
-                    changes using pull requests. You can modify the frequency at which automatic
-                    tests are run via <code>.github/workflows/cypress.yml</code>; Github does impose
-                    a limit on the number of actions you can run in a month so you may not want to
-                    modify this to run on each push.
+                    Github will automatically run any Playwright tests as a Github Action if you
+                    push changes using pull requests. You can modify the frequency at which
+                    automatic tests are run via <code>.github/workflows/playwright.yml</code>;
+                    Github does impose a limit on the number of actions you can run in a month so
+                    you may not want to modify this to run on each push.
                 </p>
                 <p>
                     If you aren't modifying any code in <code>core</code>, it should be safe to
                     bypass the built-in tests by using{' '}
-                    <a href="https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests#Excluding-and-Including-Tests">
-                        Cypress's support for skipping tests
+                    <a href="https://playwright.dev/docs/test-annotations">
+                        Playwright test annotations
                     </a>
                     . It's recommended to keep the tests around in your code base to facilitate
                     merges from upstream, and you can always re-enable them if you're concerned that
@@ -101,11 +103,9 @@ export const Page: PageType = () => {
                 </p>
                 <h3>Writing story tests</h3>
                 <p>
-                    Cypress has a lot of features, most of which aren't covered by the example
+                    Playwright has a lot of features, most of which aren't covered by the example
                     tests. Start with their{' '}
-                    <a href="https://docs.cypress.io/guides/references/best-practices">
-                        best practices
-                    </a>{' '}
+                    <a href="https://playwright.dev/docs/best-practices">best practices</a>{' '}
                     documentation which covers techniques for writing reliable tests. Note though
                     that they specifically discourage writing tests based on source text in the
                     document; since your story is composed primarily of text, you'll probably want
@@ -133,13 +133,8 @@ export const Page: PageType = () => {
                 </p>
                 <h3>Unit testing</h3>
                 <p>
-                    Windrift doesn't ship with a unit testing framework, but Cypress has some
-                    limited support for{' '}
-                    <a href="https://docs.cypress.io/guides/component-testing/introduction">
-                        component-level testing
-                    </a>{' '}
-                    in addition to browser-level testing. You could also integrate a traditional
-                    component-level test library like{' '}
+                    Windrift doesn't ship with a unit testing framework. You could integrate a
+                    traditional component-level test library like{' '}
                     <a href="https://testing-library.com/docs/react-testing-library/intro/">
                         React Testing Library
                     </a>{' '}


### PR DESCRIPTION
# Summary
This PR is stacked on #8 and addresses lizadaly/windrift#306 by replacing the Cypress documentation in `stories/manual/chapters/testing.tsx` with Playwright links and code snippets.

<details>
<summary>

# Stacked PRs in this series

</summary>

- lizadaly/windrift#312
- 6notes/windrift#1
- 6notes/windrift#2
- 6notes/windrift#3
- 6notes/windrift#4
- 6notes/windrift#5
- 6notes/windrift#6
- 6notes/windrift#7
- 6notes/windrift#8
- 6notes/windrift#9

</details>